### PR TITLE
Fix post-install patch placement for Expo SDK 54

### DIFF
--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -15,7 +15,7 @@ export const withPodfile: ConfigPlugin<{
     (config) => {
       const podFilePath = path.join(
         config.modRequest.platformProjectRoot,
-        "Podfile",
+        "Podfile"
       );
       let podfileContent = fs.readFileSync(podFilePath).toString();
 
@@ -27,24 +27,18 @@ export const withPodfile: ConfigPlugin<{
       end
     end`;
 
-      // Determine where to insert the post install build settings. We want the
-      // snippet to execute inside the `post_install` block after
-      // `react_native_post_install` has finished. The amount of lines between
-      // the `react_native_post_install` call and the end of the block can vary
-      // across Expo SDK versions, so we calculate the offset dynamically
-      // instead of using a hard coded value.
+      // Calculate the offset dynamically to add post_install` block after
+      // `react_native_post_install` has finished
       const lines = podfileContent.split("\n");
       const anchorIndex = lines.findIndex((line) =>
-        line.includes("react_native_post_install"),
+        line.includes("react_native_post_install")
       );
       if (anchorIndex === -1) {
         throw new Error(
-          "Could not find `react_native_post_install` in the Podfile",
+          "Could not find `react_native_post_install` in the Podfile"
         );
       }
-      // Find the first `end` after the `react_native_post_install` call, this is
-      // the end of the `post_install` block. Insert our snippet just before it
-      // so that `installer` is defined when the generated code runs.
+
       let offset = 0;
       for (let i = anchorIndex + 1; i < lines.length; i++) {
         offset++;

--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -27,12 +27,38 @@ export const withPodfile: ConfigPlugin<{
       end
     end`;
 
+      // Determine where to insert the post install build settings. We want the
+      // snippet to execute inside the `post_install` block after
+      // `react_native_post_install` has finished. The amount of lines between
+      // the `react_native_post_install` call and the end of the block can vary
+      // across Expo SDK versions, so we calculate the offset dynamically
+      // instead of using a hard coded value.
+      const lines = podfileContent.split("\n");
+      const anchorIndex = lines.findIndex((line) =>
+        line.includes("react_native_post_install"),
+      );
+      if (anchorIndex === -1) {
+        throw new Error(
+          "Could not find `react_native_post_install` in the Podfile",
+        );
+      }
+      // Find the first `end` after the `react_native_post_install` call, this is
+      // the end of the `post_install` block. Insert our snippet just before it
+      // so that `installer` is defined when the generated code runs.
+      let offset = 0;
+      for (let i = anchorIndex + 1; i < lines.length; i++) {
+        offset++;
+        if (lines[i].trim() === "end") {
+          break;
+        }
+      }
+
       podfileContent = mergeContents({
         tag: "post-install-build-settings",
         src: podfileContent,
         newSrc: postInstallBuildSettings,
-        anchor: `react_native_post_install`,
-        offset: 7,
+        anchor: /react_native_post_install/,
+        offset,
         comment: "#",
       }).contents;
 


### PR DESCRIPTION
## Issue
When running expo prebuild --clean --platform ios followed by pod install, the build fails with the following error:
[!] Invalid `Podfile` file: undefined local variable or method 'installer' for an instance of Pod::Podfile.

```bash
 #  from /path/to/project/ios/Podfile:53
 #  -------------------------------------------
 #  # @generated begin post-install-build-settings - expo prebuild (DO NOT MODIFY) sync-f4e2a1acf7da60b403fcf5c1d5d9517cb9953853
 >      installer.pods_project.targets.each do |target|
 #        unless target.name == 'Sentry'
 #  -------------------------------------------
The issue occurs because the generated Podfile contains code that references the installer variable outside of a post_install do |installer| block. This results in a Ruby syntax error since the installer variable is only available within the scope of the post_install block.
```


## Context

Environment:

Expo SDK: 54 beta
expo-share-extension: 4.0.1
Platform: iOS
Package manager: Bun


## Solution
The fix ensures the generated installer.pods_project.targets.each code is inserted inside the existing post_install do |installer| block, rather than at the root level of the Podfile.
Key changes:

Dynamically locate the react_native_post_install call in the Podfile
Find the corresponding end statement that closes the post_install block
Insert the build settings code just before that end statement using calculated offset
This ensures the installer variable is properly scoped and available when the generated code executes

The solution uses mergeContents with dynamic offset calculation instead of hard-coded positioning, making it robust across different Expo SDK versions and Podfile structures.

------
https://chatgpt.com/codex/tasks/task_e_68a8dc6690dc832cba30f0b3ce5c7b3c